### PR TITLE
Fixes path for subscription-manager

### DIFF
--- a/tasks/registration.yml
+++ b/tasks/registration.yml
@@ -12,7 +12,7 @@
 
 
 - name: "Check if Satellite is subscribed"
-  shell: "/usr/bin/subscription-manager list --consumed
+  shell: "/usr/sbin/subscription-manager list --consumed
     --matches='*Satellite*' | awk '/Pool ID/ {print $3}'"
   tags:
     - "rhn"
@@ -21,7 +21,7 @@
 
 #Get the pool id for the pool that contains the Satellite product
 - name: "RHN | get RHN pool id"
-  shell: "/usr/bin/subscription-manager list --all --available
+  shell: "/usr/sbin/subscription-manager list --all --available
     --matches='*Satellite*' | awk '/Pool ID/ {print $3}' | head -1"
   tags:
     - "rhn"
@@ -37,7 +37,7 @@
 
 #Attaching the system to the right Pool
 - name: "RHN | subscribing to the right pool"
-  command: "/usr/bin/subscription-manager attach
+  command: "/usr/sbin/subscription-manager attach
     --pool={{ satellite_deployment_pool_id }}"
   tags:
     - "rhn"
@@ -48,7 +48,7 @@
 
 #Enabling the repos
 - name: "RHN | enabling the right repos"
-  command: "/usr/bin/subscription-manager repos --disable '*' --enable
+  command: "/usr/sbin/subscription-manager repos --disable '*' --enable
     rhel-7-server-satellite-{{ satellite_deployment_version }}-rpms
     --enable rhel-7-server-rpms --enable rhel-server-rhscl-7-rpms"
   tags:


### PR DESCRIPTION
```
[root@anslab1 ~]# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.3 (Maipo)

[root@anslab1 ~]# yum update
Loaded plugins: langpacks, package_upload, product-id, search-disabled-repos, subscription-manager
rhel-7-server-extras-rpms
rhel-7-server-rpms
rhel-7-server-satellite-tools-6.2-rpms
rhel-server-rhscl-7-rpms
No packages marked for update

[root@anslab1 ~]# which subscription-manager
/usr/sbin/subscription-manager

[root@anslab1 ~]# ls -l /usr/sbin/subscription-manager
-rwxr-xr-x. 1 root root 2623 Sep 13  2016 /usr/sbin/subscription-manager

[root@anslab1 ~]# ls -l /usr/bin/subscription-manager
lrwxrwxrwx. 1 root root 22 Apr  2 23:12 /usr/bin/subscription-manager -> /usr/bin/consolehelper

```
The role wouldn't work with proxy settings passed as environment variables, the reason being that subscription-manager under /usr/bin is a link to something else.